### PR TITLE
feat: run Jest tests only on changed TypeScript files

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-  "*.ts": "yarn test src",
+  "!(*config).ts": "yarn test --bail --findRelatedTests",
   "*": "yarn lint"
 }

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -19,7 +19,7 @@ const config: Config = {
     // clearMocks: false,
 
     // Indicates whether the coverage information should be collected while executing the test
-    collectCoverage: true,
+    collectCoverage: false,
 
     // An array of glob patterns indicating a set of files for which coverage information should be collected
     // collectCoverageFrom: undefined,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "scripts": {
     "test": "jest",
+    "test:coverage": "jest --coverage",
     "postinstall": "husky",
     "lint": "eslint"
   }


### PR DESCRIPTION
During lint-staged, runs Jest tests only on changed files and those affected