### PR TITLE
🔧 chore: add TypeScript settings which were "deprecated" from VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,8 +3,12 @@
     "**/.yarn": true,
     "**/.pnp.*": true
   },
+  // VSCode's TypeScript extension settings
   "js/ts.tsdk.path": ".yarn/sdks/typescript/lib",
   "js/ts.tsdk.promptToUseWorkspaceVersion": true,
+  // Cursor's TypeScript extension settings
+  "typescript.tsdk": ".yarn/sdks/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
   "jest.runMode": {
     "type": "on-save"
   },


### PR DESCRIPTION
While it is true that the two directives/settings were deprecated from VS Code, they seem are necessary for Cursor to work properly. Without them, the imports were resolving correctly as far as build and such, but showed with "errors" within the IDE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced IDE configuration for TypeScript tooling integration and workspace environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->